### PR TITLE
Fixed for missing card fields and infinite loading state. 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 *** Shift4 for WooCommerce Changelog ***
 
+2025-04-10 - version 1.0.3
+* Fixed: Card input fields were missing in the Shift4 payment method after changing the product quantity on the WooCommerce checkout page.
+* Fixed: Submit button remained in a loading state indefinitely when an error occurred during checkout.
+* Fixed: Error message was not displayed if the user navigated between steps on the WooCommerce checkout page.
+
 2025-04-04 - version 1.0.2
 * Fixed an issue that duplicates card fields
 

--- a/shift4.php
+++ b/shift4.php
@@ -2,9 +2,9 @@
 /*
  * Plugin Name: Shift4
  * Description: WooCommerce payments via the Shift4 platform
- * Version: 1.0.2
- * Plugin URI: https://www.shift4.com/
- * Author: Gene Commerce
+ * Version: 1.0.3
+ * Plugin URI: https://dev.shift4.com/docs/plugins/woo-commerce/
+ * Author: Shift4
  * Text Domain: shift4
  * Requires PHP: 8.0
  * WC tested up to: 8.4.0


### PR DESCRIPTION
Fixed issues:
* Card input fields were missing in the Shift4 payment method after changing the product quantity on the WooCommerce checkout page.
* Submit button remained in a loading state indefinitely when an error occurred during checkout.
* Error message was not displayed if the user navigated between steps on the WooCommerce checkout page.